### PR TITLE
misc

### DIFF
--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.4
 
 RUN apk --update-cache upgrade && \
     apk add \

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -4,8 +4,10 @@ RUN apk --update-cache upgrade && \
     apk add \
       bash \
       bind-tools \
+      coreutils \
       curl \
       ncurses \
+      tzdata \
       && \
     rm -f /var/cache/apk/*
 

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -20,5 +20,8 @@ RUN cd /tmp/ && \
     rm -f openssl-1.0.2e-chacha.pm.tar.gz && \
     rm -fr bin/
 
+# Install RFC mapping file.
+RUN curl -L -o /etc/mapping-rfc.txt https://testssl.sh/mapping-rfc.txt
+
 ENTRYPOINT ["/testssl.sh"]
 CMD ["-h"]


### PR DESCRIPTION
* rebase on alpine 3.4 (latest current release)
* avoid failure with cert date format
* avoid warning "No mapping file found"