### PR TITLE
upgrade to openssl 1.02i and add ipv6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ test:
 	@echo '====> Test that images have correct versions.'
 	docker run -it testssl:master --version | grep '^[[:space:]]*testssl.sh'
 	@echo '====> Test SSL of a website.'
-	docker run -t testssl:master https://members.ise.com
+	docker run -t testssl:master https://login.ise.com

--- a/README.md
+++ b/README.md
@@ -54,4 +54,5 @@ Quay registry: [http://status.quay.io/](http://status.quay.io/)
 License
 -------
 
+This repo, testssl, and openssl are licensed under the GPLv2.
 See [LICENSE](LICENSE).

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -1,5 +1,7 @@
 FROM alpine:3.4
 
+ENV TARBALL="openssl-1.0.2e-chacha.pm.tar.gz"
+
 RUN apk --update-cache upgrade && \
     apk add \
       bash \
@@ -14,10 +16,10 @@ RUN apk --update-cache upgrade && \
 # Use the statically-compiled version of openssl from
 # https://testssl.sh/
 RUN cd /tmp/ && \
-    curl -L -O https://testssl.sh/openssl-1.0.2e-chacha.pm.tar.gz && \
-    tar xvzf openssl-1.0.2e-chacha.pm.tar.gz && \
+    curl -L -O https://testssl.sh/${TARBALL} && \
+    tar xvzf ${TARBALL} && \
     cp -f bin/openssl.Linux.x86_64 /usr/bin/openssl && \
-    rm -f openssl-1.0.2e-chacha.pm.tar.gz && \
+    rm -f ${TARBALL} && \
     rm -fr bin/
 
 # Install RFC mapping file.

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -1,6 +1,6 @@
 FROM alpine:3.4
 
-ENV TARBALL="openssl-1.0.2e-chacha.pm.tar.gz"
+ENV TARBALL="openssl-1.0.2i-chacha.pm.ipv6.Linux+FreeBSD.tar.gz"
 
 RUN apk --update-cache upgrade && \
     apk add \


### PR DESCRIPTION
* base: store openssl version in env var for DRYer build
* clarify that all source is GPLv2
* test against a more interesting TLS site
* upgrade to openssl 1.02i and add ipv6

Resolves https://github.com/jumanjihouse/docker-testssl/issues/7

Resolves https://github.com/jumanjihouse/docker-testssl/issues/8