### PR TITLE
update to openssl 1.0.2k

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ test:
 	docker run -it testssl:2.8    --version | grep '^[[:space:]]*testssl.sh.*2.8'
 	docker run -it testssl:2.9dev --version | grep '^[[:space:]]*testssl.sh.*2.9dev'
 	@echo '====> Test SSL of a website.'
-	docker run -t testssl:2.8    --ip one https://www.google.com/
-	docker run -t testssl:2.9dev --ip one https://www.google.com/
+	docker run -t testssl:2.8    --heartbleed --ip one https://www.google.com/
+	docker run -t testssl:2.9dev --heartbleed --ip one https://www.google.com/

--- a/src/Dockerfile-base
+++ b/src/Dockerfile-base
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-ENV TARBALL="openssl-1.0.2i-chacha.pm.ipv6.Linux+FreeBSD.tar.gz"
+ENV TARBALL="openssl-1.0.2k-chacha.pm.ipv6.Linux+FreeBSD.tar.gz"
 
 RUN apk --update-cache upgrade && \
     apk add \
@@ -18,6 +18,7 @@ RUN apk --update-cache upgrade && \
 RUN cd /tmp/ && \
     curl -L -O https://testssl.sh/${TARBALL} && \
     tar xvzf ${TARBALL} && \
+    mv bin/openssl.Linux.x86_64.static bin/openssl.Linux.x86_64 && \
     cp -f bin/openssl.Linux.x86_64 /usr/bin/openssl && \
     rm -f ${TARBALL} && \
     rm -fr bin/


### PR DESCRIPTION
@drwetter wrote at
https://github.com/jumanjihouse/docker-testssl/pull/17

> I recompiled the binaries.
> They can be used for 2.8 and 2.9dev as well.
> 2.9dev comes with STARTTLS postgresql support
> and CONNECT HTTP/1.0 which seems to be needed for some proxies.